### PR TITLE
Enable trust proxy for rate limiting

### DIFF
--- a/server.js
+++ b/server.js
@@ -19,6 +19,7 @@ const manifestRoutes = require('./routes/manifest');
 const { updateManifest } = require('./services/manifestService');
 
 const app = express();
+app.set("trust proxy", 1);
 const PORT = process.env.PORT || 3000;
 
 // Security middleware


### PR DESCRIPTION
## Summary
- enable `trust proxy` in Express so express-rate-limit works properly

## Testing
- `npm test` *(fails: No tests found)*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_686f8403da4c8329be33136852f4dc52