### PR TITLE
Fix initial tab selection

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1219,7 +1219,7 @@
     </div>
 
     <!-- My Armor Tab -->
-    <div id="inventory" class="content-section">
+    <div id="inventory" class="content-section active">
       <div class="inventory-section">
         <h2 style="color: #ffd700; text-align: center; margin-bottom: 20px">
           My Armor Collection
@@ -1252,7 +1252,7 @@
       </div>
     </div>
 
-    <div id="artifact" class="content-section active">
+    <div id="artifact" class="content-section">
       <div class="artifact-container">
         <div class="artifact-filters" id="artifactFilters">
           <button class="element-filter-btn" data-element="solar">Solar</button>


### PR DESCRIPTION
## Summary
- ensure the Inventory content section is the default active tab

## Testing
- `npm test -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_686ffa4e32008329b384bcad37463255