### PR TITLE
Revamp optimizer layout with pagination

### DIFF
--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -159,6 +159,43 @@
         box-shadow: 0 0 30px rgba(138, 43, 226, 0.3);
       }
 
+      .optimizer-layout {
+        display: flex;
+        gap: 20px;
+        align-items: flex-start;
+      }
+
+      .optimizer-layout .stat-selector-section {
+        width: 300px;
+        flex-shrink: 0;
+      }
+
+      .build-results {
+        flex: 1;
+      }
+
+      .pagination-controls {
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        gap: 10px;
+        margin-top: 10px;
+      }
+
+      .pagination-controls button {
+        padding: 6px 12px;
+        background: rgba(50, 50, 60, 0.8);
+        border: 1px solid #444;
+        border-radius: 6px;
+        color: #fff;
+        cursor: pointer;
+      }
+
+      .pagination-controls button:disabled {
+        opacity: 0.5;
+        cursor: not-allowed;
+      }
+
       .stat-selector-section {
         background: rgba(30, 30, 40, 0.8);
         border-radius: 20px;
@@ -1022,7 +1059,7 @@
         box-shadow: 0 0 15px rgba(255, 215, 0, 0.8);
       }
 
-      .optimization-results {
+      .build-results {
         margin-top: 30px;
       }
 

--- a/public/index.html
+++ b/public/index.html
@@ -49,11 +49,11 @@
 
     <!-- Armor Optimizer Tab -->
     <div id="armor" class="content-section active">
-      <!-- Stat Selector Section -->
-      <div class="stat-selector-section">
-        <h2 style="color: #ffd700; text-align: center; margin-bottom: 20px">
-          Target Stat Distribution
-        </h2>
+      <div id="optimizerLayout" class="optimizer-layout">
+        <div class="stat-selector-section">
+          <h2 style="color: #ffd700; text-align: center; margin-bottom: 20px">
+            Target Stat Distribution
+          </h2>
         <div style="display: flex; justify-content: center; align-items: center; gap: 20px; margin-bottom: 20px">
           <div class="class-selector">
             <button class="class-button" id="topHunterClass" data-class="hunter" onclick="selectClass('hunter')">Hunter</button>
@@ -67,35 +67,29 @@
           </div>
         </div>
         <div class="stat-allocator" id="statAllocator"></div>
-      </div>
-
-        <!-- Optimization Button -->
-        <div style="margin-top: 20px; text-align: center">
-          <button
-            class="auth-button-small"
-            onclick="findOptimalBuilds()"
-            style="
-              background: linear-gradient(135deg, #4caf50, #2e7d32);
-              padding: 15px 40px;
-              font-size: 1.2em;
-            "
-          >
-            Find Optimal Builds
-          </button>
+          <div style="margin-top: 20px; text-align: center">
+            <button
+              class="auth-button-small"
+              onclick="findOptimalBuilds()"
+              style="
+                background: linear-gradient(135deg, #4caf50, #2e7d32);
+                padding: 15px 40px;
+                font-size: 1.2em;
+              "
+            >
+              Find Optimal Builds
+            </button>
+          </div>
         </div>
-      </div>
 
-      <!-- Optimization Results Section -->
-      <div
-        id="optimizationResults"
-        class="optimization-results"
-        style="display: none"
-      >
-        <div class="armor-optimizer-section">
-          <h2 style="color: #ffd700; text-align: center; margin-bottom: 20px">
-            Optimization Results
-          </h2>
-          <div id="resultsContainer"></div>
+        <div id="optimizationResults" class="build-results" style="display: none">
+          <div class="armor-optimizer-section">
+            <h2 style="color: #ffd700; text-align: center; margin-bottom: 20px">
+              Optimization Results
+            </h2>
+            <div id="resultsContainer"></div>
+            <div id="paginationControls"></div>
+          </div>
         </div>
       </div>
 


### PR DESCRIPTION
## Summary
- reposition optimizer layout with stat selector on the left
- show build results on the right with pagination
- support pagination in JS (25 builds per page)
- remove masterwork assumption in build stat totals

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687031731c30832996db3c33586dc603