### PR TITLE
Fix armor inventory base URL

### DIFF
--- a/public/js/api.js
+++ b/public/js/api.js
@@ -1,7 +1,14 @@
 // api.js - Frontend API wrapper for Bungie API calls
 const API = {
   // Base configuration
-  baseURL: window.location.origin,
+  // Determine base URL. If the page is opened directly from the filesystem,
+  // window.location.origin will be "null" which breaks API calls.
+  // Fallback to localhost in that case so the app still works when the
+  // backend is running locally.
+  baseURL:
+    window.location.origin && window.location.origin !== "null"
+      ? window.location.origin
+      : "http://localhost:3000",
   isAuthenticated: false,
 
   // Helper method for API calls


### PR DESCRIPTION
## Summary
- ensure API calls work when `window.location.origin` is empty

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870bf9945e88329bbee76950de9716c