### PR TITLE
Add debug logs for OAuth login

### DIFF
--- a/routes/auth.js
+++ b/routes/auth.js
@@ -14,6 +14,12 @@ function generateState() {
 
 // OAuth login route
 router.get("/login", (req, res) => {
+  // --- Start of Debugging Code ---
+  console.log("--- DEBUG: /auth/login route hit ---");
+  console.log("BUNGIE_CLIENT_ID:", process.env.BUNGIE_CLIENT_ID);
+  console.log("OAUTH_REDIRECT_URI:", process.env.OAUTH_REDIRECT_URI);
+  // --- End of Debugging Code ---
+
   const state = generateState();
   req.session.oauthState = state;
 
@@ -24,7 +30,13 @@ router.get("/login", (req, res) => {
     state: state,
   });
 
-  res.redirect(`${BUNGIE_AUTH_URL}?${params.toString()}`);
+  const finalRedirectUrl = `${BUNGIE_AUTH_URL}?${params.toString()}`;
+
+  // --- More Debugging ---
+  console.log("Final Redirect URL being sent to browser:", finalRedirectUrl);
+  // --- End More Debugging ---
+
+  res.redirect(finalRedirectUrl);
 });
 
 // OAuth callback route


### PR DESCRIPTION
## Summary
- add console debug statements in `/auth/login` route

## Testing
- `npm test` *(fails: No tests found)*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_6871805f3ca0832993e8b3dd41e4359f