### PR TITLE
Fix inventory fetch and add pagination UI

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -113,6 +113,11 @@
         <div id="armorGridContainer" class="armor-grid">
           <!-- Armor items will be populated here -->
         </div>
+        <div id="armorPagination" class="pagination-controls" style="display:none">
+          <button id="armorPrevPage">Previous</button>
+          <span id="armorPageInfo"></span>
+          <button id="armorNextPage">Next</button>
+        </div>
       </div>
     </div>
 

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -411,6 +411,8 @@ let armorItems = [];
 let filteredArmorItems = [];
 let armorLoaded = false;
 let armorLoading = false;
+let armorCurrentPage = 1;
+const armorItemsPerPage = 20;
 
 async function loadArmorInventory() {
   const armorGrid = document.getElementById("armorGridContainer");
@@ -578,6 +580,40 @@ function displayNoArmorMessage(message = "Sign in with Bungie to view your armor
   }
 }
 
+function updateArmorPagination(totalPages) {
+  const info = document.getElementById("armorPageInfo");
+  const prev = document.getElementById("armorPrevPage");
+  const next = document.getElementById("armorNextPage");
+  const container = document.getElementById("armorPagination");
+  if (!info || !prev || !next || !container) return;
+
+  info.textContent = `Page ${armorCurrentPage} of ${totalPages}`;
+  prev.disabled = armorCurrentPage <= 1;
+  next.disabled = armorCurrentPage >= totalPages;
+  container.style.display = totalPages > 1 ? "flex" : "none";
+}
+
+function renderArmorPage() {
+  const totalPages = Math.ceil(filteredArmorItems.length / armorItemsPerPage) || 1;
+  if (armorCurrentPage > totalPages) armorCurrentPage = totalPages;
+  if (armorCurrentPage < 1) armorCurrentPage = 1;
+  const start = (armorCurrentPage - 1) * armorItemsPerPage;
+  const end = start + armorItemsPerPage;
+  const pageItems = filteredArmorItems.slice(start, end);
+  displayArmorItems(pageItems);
+  updateArmorPagination(totalPages);
+}
+
+function goToNextArmorPage() {
+  armorCurrentPage++;
+  renderArmorPage();
+}
+
+function goToPrevArmorPage() {
+  armorCurrentPage--;
+  renderArmorPage();
+}
+
 function setupArmorFilters() {
   // Check if already set up
   const searchInput = document.getElementById("armorSearchInput");
@@ -603,6 +639,17 @@ function setupArmorFilters() {
   if (slotFilter && !slotFilter.dataset.initialized) {
     slotFilter.addEventListener("change", () => applyArmorFilters());
     slotFilter.dataset.initialized = "true";
+  }
+
+  const prev = document.getElementById("armorPrevPage");
+  const next = document.getElementById("armorNextPage");
+  if (prev && !prev.dataset.initialized) {
+    prev.addEventListener("click", () => goToPrevArmorPage());
+    prev.dataset.initialized = "true";
+  }
+  if (next && !next.dataset.initialized) {
+    next.addEventListener("click", () => goToNextArmorPage());
+    next.dataset.initialized = "true";
   }
 }
 
@@ -640,7 +687,8 @@ function applyArmorFilters() {
   });
   
   console.log(`Filtered to ${filteredArmorItems.length} items`);
-  displayArmorItems(filteredArmorItems);
+  armorCurrentPage = 1;
+  renderArmorPage();
 }
 
 async function refreshData() {

--- a/routes/api.js
+++ b/routes/api.js
@@ -41,62 +41,14 @@ async function getProfileWithAllItems(membershipType, membershipId, session) {
   //            300+  = Item component sets we need for stats & sockets
   const CORE = "102,201,205,300,301,302,304,305,307";
 
-  // ---- page 0 ----
-  const initial = await makeApiRequest(
+  // Destiny profile inventories are returned in a single response. Fetch once
+  // and return the result.
+  const profile = await makeApiRequest(
     `/Destiny2/${membershipType}/Profile/${membershipId}/`,
-    { params: { components: CORE, page: 0 }, session }
+    { params: { components: CORE }, session }
   );
 
-  console.log(
-    `Fetched page 0: ${
-      initial.profileInventory?.data?.items?.length || 0
-    } items`
-  );
-  if (initial.profileInventory?.data?.items?.length) {
-    console.log(
-      "Item hashes:",
-      initial.profileInventory.data.items.map((i) => i.itemHash)
-    );
-  }
-
-  const vaultItems = [...(initial.profileInventory?.data?.items ?? [])];
-  let hasMore   = initial.profileInventory?.hasMore ?? false;   // <-- correct level
-  let page      = 1;
-
-  // ---- extra pages ----
-  while (hasMore) {
-    const resp = await makeApiRequest(
-      `/Destiny2/${membershipType}/Profile/${membershipId}/`,
-      { params: { components: CORE, page }, session }
-    );
-
-    console.log(
-      `Fetched page ${page}: ${
-        resp.profileInventory?.data?.items?.length || 0
-      } items`
-    );
-    if (resp.profileInventory?.data?.items?.length) {
-      console.log(
-        "Item hashes:",
-        resp.profileInventory.data.items.map((i) => i.itemHash)
-      );
-    }
-
-    if (resp.profileInventory?.data?.items?.length) {
-      vaultItems.push(...resp.profileInventory.data.items);
-    }
-
-    if (resp.itemComponents) {
-      mergeItemComponents(initial.itemComponents, resp.itemComponents);
-    }
-
-    hasMore = resp.profileInventory?.hasMore ?? false;          // <-- correct level
-    page++;
-  }
-
-  // stitch vault back into the first response so the shape stays the same
-  initial.profileInventory.data.items = vaultItems;
-  return initial;
+  return profile;
 }
 
 // Get all character and vault inventory


### PR DESCRIPTION
## Summary
- fetch profile inventory only once since it's not paginated
- add client-side pagination variables and handlers for armor grid
- show pagination controls in the armor view

## Testing
- `npm install`
- `npm test -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_6872a95a87e0832990a4b1c1fc819400