### PR TITLE
Rewrite README to highlight application experience

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,313 +1,43 @@
-# Destiny 2 Build Planner - Production Setup Guide
-
-This is a production-ready Destiny 2 Build Planner with full Bungie API integration, similar to Destiny Item Manager.
-
-## Features
-
-- ✅ Secure OAuth 2.0 authentication with Bungie.net
-- ✅ Real-time inventory loading from your Destiny 2 account
-- ✅ Automatic manifest updates with SQLite caching
-- ✅ Server-side API proxy for security
-- ✅ Session management with MongoDB
-- ✅ Rate limiting and security headers
-- ✅ Docker support for easy deployment
-- ✅ Production-ready error handling
-
-## Prerequisites
-
-- Node.js 18+ (or Docker)
-- MongoDB (or Docker)
-- A registered Bungie.net application
-- SSL certificate (for production)
-
-## Quick Start
-
-### 1. Register a Bungie Application
-
-1. Go to [https://www.bungie.net/en/Application](https://www.bungie.net/en/Application)
-2. Create a new application
-3. Set the OAuth redirect URL to: `https://your-domain.com/auth/callback`
-4. Note down:
-   - API Key
-   - OAuth Client ID
-   - OAuth Client Secret
-
-### 2. Clone and Setup
-
-```bash
-# Clone the repository
-git clone <your-repo-url>
-cd destiny2-build-planner
-
-# Install dependencies
-npm install
-
-# Copy environment template
-cp .env.example .env
-
-# Edit .env with your credentials
-nano .env
-```
-
-### 3. Configure Environment
-
-Edit `.env` file:
-
-```env
-# Required configurations
-NODE_ENV=production
-PORT=3000
-CLIENT_URL=https://your-domain.com
-MONGODB_URI=mongodb://localhost:27017/d2-builder
-SESSION_SECRET=generate-a-long-random-string-here
-BUNGIE_API_KEY=your-api-key
-BUNGIE_CLIENT_ID=your-client-id
-BUNGIE_CLIENT_SECRET=your-client-secret
-OAUTH_REDIRECT_URI=https://your-domain.com/auth/callback
-ADMIN_API_KEY=generate-another-random-string
-```
-
-### 4. Build Frontend
-
-Place the production HTML file in the `public` directory:
-
-```bash
-mkdir -p public/js
-# Copy the provided index.html to public/
-# Copy the api.js to public/js/
-```
-
-### 5. Start the Application
-
-#### Option A: Using Node.js directly
-
-```bash
-# Development
-npm run dev
-
-# Production
-npm start
-```
-
-#### Option B: Using Docker Compose (Recommended)
-
-```bash
-# Start all services
-docker-compose up -d
-
-# View logs
-docker-compose logs -f
-
-# Stop services
-docker-compose down
-```
-
-## Production Deployment
-
-### 1. Using Docker (Recommended)
-
-```bash
-# Build and run with Docker Compose
-docker-compose up -d
-```
-
-This will start:
-- Node.js application server
-- MongoDB for session storage
-- Nginx reverse proxy (optional)
-
-### 2. Manual Deployment
-
-#### Install PM2 for process management:
-
-```bash
-npm install -g pm2
-
-# Start the application
-pm2 start server.js --name d2-builder
-
-# Save PM2 configuration
-pm2 save
-pm2 startup
-```
-
-#### Configure Nginx:
-
-```nginx
-server {
-    listen 80;
-    server_name your-domain.com;
-    return 301 https://$server_name$request_uri;
-}
-
-server {
-    listen 443 ssl http2;
-    server_name your-domain.com;
-
-    ssl_certificate /path/to/fullchain.pem;
-    ssl_certificate_key /path/to/privkey.pem;
-
-    location / {
-        proxy_pass http://localhost:3000;
-        proxy_http_version 1.1;
-        proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection 'upgrade';
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
-        proxy_cache_bypass $http_upgrade;
-    }
-}
-```
-
-### 3. SSL Setup
-
-For production, you must use HTTPS:
-
-```bash
-# Using Let's Encrypt with Certbot
-sudo certbot --nginx -d your-domain.com
-```
-
-## API Endpoints
-
-### Authentication
-- `GET /auth/login` - Start OAuth flow
-- `GET /auth/callback` - OAuth callback
-- `POST /auth/logout` - Logout user
-- `GET /auth/status` - Check auth status
-
-### Inventory Management
-- `GET /api/inventory` - Get user's inventory
-- `GET /api/character/:id` - Get character data
-- `POST /api/transfer` - Transfer items
-- `POST /api/equip` - Equip items
-
-### Manifest
-- `GET /manifest/item/:hash` - Get item definition
-- `POST /manifest/items` - Get multiple item definitions
-- `GET /manifest/stats` - Get stat definitions
-- `GET /manifest/mods/armor` - Get armor mods
-
-## File Structure
-
-```
-destiny2-build-planner/
-├── server.js              # Main server file
-├── routes/
-│   ├── auth.js           # Authentication routes
-│   ├── api.js            # API proxy routes
-│   └── manifest.js       # Manifest data routes
-├── services/
-│   └── manifestService.js # Manifest management
-├── middleware/
-│   └── bungie.js         # Bungie API middleware
-├── public/
-│   ├── index.html        # Main frontend
-│   └── js/
-│       └── api.js        # Client API service
-├── data/
-│   └── manifest/         # Manifest cache directory
-├── .env                  # Environment variables
-├── package.json          # Dependencies
-├── Dockerfile            # Docker configuration
-└── docker-compose.yml    # Docker Compose config
-```
-
-## Security Considerations
-
-1. **Never expose secrets**: All API keys and secrets are server-side only
-2. **Use HTTPS**: Required for OAuth and secure cookies
-3. **Rate limiting**: Implemented to prevent API abuse
-4. **CORS**: Configured to only allow your domain
-5. **Session security**: HTTP-only cookies with secure flag
-6. **Input validation**: All user inputs are validated
-
-## Monitoring & Maintenance
-
-### Logs
-
-```bash
-# View application logs
-pm2 logs d2-builder
-
-# Or with Docker
-docker-compose logs -f app
-```
-
-### Manifest Updates
-
-The manifest updates automatically every 6 hours. To manually update:
-
-```bash
-# Using the admin endpoint
-curl -X POST https://your-domain.com/manifest/update \
-  -H "X-Admin-Key: your-admin-api-key"
-```
-
-### Database Backup
-
-```bash
-# Backup MongoDB
-mongodump --uri="mongodb://localhost:27017/d2-builder" --out=./backup
-
-# Restore
-mongorestore --uri="mongodb://localhost:27017/d2-builder" ./backup/d2-builder
-```
-
-## Troubleshooting
-
-### Common Issues
-
-1. **"Not authenticated" errors**
-   - Check if cookies are enabled
-   - Verify OAuth redirect URL matches exactly
-   - Ensure HTTPS is working
-
-2. **Manifest download fails**
-   - Check disk space
-   - Verify Bungie API key is valid
-   - Check network connectivity
-
-3. **OAuth callback fails**
-   - Verify redirect URI in Bungie app settings
-   - Check CLIENT_URL in .env matches your domain
-   - Ensure session secret is set
-
-### Debug Mode
-
-Set `NODE_ENV=development` in `.env` for detailed error messages.
-
-## Performance Optimization
-
-1. **Enable caching**: The manifest service caches definitions
-2. **Use CDN**: Serve static files through a CDN
-3. **Enable compression**: Gzip responses in Nginx
-4. **Database indexes**: Ensure MongoDB indexes are created
-
-## Contributing
-
-1. Fork the repository
-2. Create a feature branch
-3. Make your changes
-4. Submit a pull request
-
-## License
-
-MIT License - See LICENSE file for details
-
-## Support
-
-For issues and questions:
-- Check the [Bungie API documentation](https://bungie-net.github.io/)
-- Review server logs for errors
-- Ensure all environment variables are set correctly
-
-## Credits
-
-Built with:
-- Express.js for the backend
-- SQLite for manifest storage
-- MongoDB for session management
-- Bungie.net API for game data
+# Destiny 2 Build Planner
+
+Destiny 2 Build Planner is a full-stack companion for Guardians who want to theorycraft, organize, and execute builds without leaving the Bungie ecosystem. It pairs a secure OAuth-backed backend with a lightweight client so players can inspect inventory, fine tune armor stat tiers, and manage their loadouts in real time.
+
+## What the application offers
+- **Single sign-on with Bungie.net** – Users authenticate directly against Bungie's OAuth 2.0 flow, and the server stores a short-lived session that can securely call player-specific APIs on their behalf.
+- **Unified inventory visibility** – Character equipment, vault contents, and profile items are merged into a single response to eliminate pagination and context switching while browsing gear.
+- **Build crafting data** – Item definitions, stat rolls, socket plug data, and mod availability are hydrated from the local Destiny manifest so players can evaluate synergies before locking in a build.
+- **Actionable loadout management** – Transfer items between characters, equip weapons or armor, inspect saved loadouts, and surface vendor inventory (such as armor mods) from the same interface.
+- **Production-ready hardening** – Helmet, rate limiting, MongoDB-backed sessions, and a server-side API proxy keep personal accounts and Bungie credentials safe even in public deployments.
+
+## How it works
+1. **Authenticate** – After OAuth, the server keeps the Bungie access token inside an encrypted session stored in MongoDB, exposing only minimal state to the browser.
+2. **Fetch player data** – Inventory endpoints combine profile, character, and vault responses, stitching item component buckets together so every stat and socket comes through in a single payload.
+3. **Enrich with manifest metadata** – A background manifest service downloads and indexes the latest game definitions into SQLite, enabling instant lookups for item names, stat descriptions, and mod sockets without repeatedly hitting Bungie's servers.
+4. **Act on gear** – When a player moves or equips an item, the API proxy signs the request with their stored token, applies Bungie's rate limits, and returns the authoritative response for UI feedback.
+
+## Key backend capabilities
+- **Routes**
+  - `/auth` – Handles OAuth handshakes, session creation, and membership resolution.
+  - `/api/inventory`, `/api/search`, `/api/character/:id` – Provide inventory browsing, filtered searches, and character-specific details.
+  - `/api/transfer` & `/api/equip` – Mirror Bungie's gear management actions while enforcing authentication and retry-safe error handling.
+  - `/api/loadouts` & `/api/vendors` – Surface saved loadouts and rotating vendor stock for mod and gear planning.
+  - `/manifest/*` – Serve cached manifest slices (items, stats, mods) to the client with millisecond response times.
+- **Security** – Session cookies are HTTP-only, CORS is locked to an allowed origin, and health/metrics endpoints give operators visibility without exposing sensitive data.
+- **Scalability** – Rate limits protect Bungie quotas, manifest caching drastically reduces outbound requests, and the service can run behind Nginx or in Docker with minimal configuration.
+
+## Destiny manifest lifecycle
+- On startup, the manifest service checks Bungie's published version and downloads the latest database if necessary.
+- The SQLite payload is unzipped, indexed, and stored under `data/manifest/` with a `version.json` file documenting provenance.
+- Subsequent definition lookups are cached in-memory with automatic eviction to ensure high throughput for repeated queries.
+
+## Typical user journey
+1. Log in with Bungie.net and select the active Destiny membership.
+2. Review combined character and vault inventories, filtering by slot or searching by name.
+3. Inspect stat breakdowns and sockets for high-value armor rolls while previewing available mods.
+4. Transfer or equip items to lock in the desired loadout, optionally saving presets directly through Bungie's loadout API.
+
+## Why it matters
+Unlike simple inventory viewers, Destiny 2 Build Planner emphasizes actionable insights. Guardians can immediately see how stat tiers change when swapping armor, understand which mods are currently purchasable, and push updates back into the game without juggling multiple tools. The result is a smoother pre-raid or PvP preparation workflow that keeps focus on crafting the perfect build rather than fighting API limitations.
+
+---
+Want to extend the experience? Explore the Express routes in `routes/`, the manifest helpers in `services/`, and the production-ready deployment assets in the repository to tailor the planner to your fireteam's needs.


### PR DESCRIPTION
## Summary
- replace the setup-focused README with an overview that describes the Destiny 2 Build Planner experience
- highlight authentication, inventory management, loadout actions, and manifest-driven insights that the app provides
- document how the backend routes, security posture, and manifest lifecycle support the player journey

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cc8254c6ac8329a5bc57afef2f4cd1